### PR TITLE
LateNight: Fix keylock icon colors

### DIFF
--- a/res/skins/LateNight/palemoon/buttons/btn__keylock.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__keylock.svg
@@ -25,11 +25,9 @@
   <defs
      id="defs6" />
   <path
+     id="rect4195"
      style="fill:#3d3d3c;fill-opacity:1;stroke:none;stroke-opacity:1"
-     fill="#766d65"
-     color="#000001"
-     d="m 4,8 v 7 H 17 V 8 Z m 6,2 h 1 v 3 h -1 z"
-     id="rect4195" />
+     d="m 10,10 c 0,1 0,2 0,3 0.333333,0 0.666667,0 1,0 0,-1 0,-2 0,-3 -0.333333,0 -0.666667,0 -1,0 z M 4,8 c 4.3333333,0 8.666667,0 13,0 0,2.333333 0,4.666667 0,7 -4.333333,0 -8.6666667,0 -13,0 0,-2.333333 0,-4.666667 0,-7 z" />
   <path
      id="path1060"
      style="fill:#3d3d3c;fill-opacity:1;stroke:none;stroke-width:1.70255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"

--- a/res/skins/LateNight/palemoon/buttons/btn__keylock_active_34.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__keylock_active_34.svg
@@ -26,10 +26,8 @@
      id="defs6" />
   <path
      id="rect4195"
-     d="m 4,8 v 7 H 17 V 8 Z m 6,2 h 1 v 3 h -1 z"
-     color="#000001"
-     fill="#766d65"
-     style="fill:#559b99;fill-opacity:1;stroke:none" />
+     style="fill:#559b99;fill-opacity:1;stroke:none"
+     d="m 10,10 c 0,1 0,2 0,3 0.333333,0 0.666667,0 1,0 0,-1 0,-2 0,-3 -0.333333,0 -0.666667,0 -1,0 z M 4,8 c 4.3333333,0 8.666667,0 13,0 0,2.333333 0,4.666667 0,7 -4.333333,0 -8.6666667,0 -13,0 0,-2.333333 0,-4.666667 0,-7 z" />
   <path
      d="M 10.5,2.5 C 8.0147186,2.5 6,4.5147186 6,7 V 8 H 8 V 7 C 8,5.6192881 9.1192881,4.5 10.5,4.5 11.880712,4.5 13,5.6192881 13,7 v 1 h 2 V 7 C 15,4.5147186 12.985281,2.5 10.5,2.5 Z"
      style="fill:#559b99;fill-opacity:1;stroke:none;stroke-width:1.70255;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"


### PR DESCRIPTION
Selecting the rectangle in Inkscape, then removing path effects + simplify + reverse did the trick.