### PR TITLE
PaleMoon: add debug colors to DeckSettings layouts

### DIFF
--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -1019,6 +1019,10 @@ WTrackMenu QMenu QCheckBox,
 #AuxSubTitle {
   color: #0bd9d1;
 }
+/* Prevent cut-off or shifted stars on macOS */
+WStarRating {
+  background-color: #1e1e1e;
+}
 
 /* green for Fx 1/2 */
 #FxUnit1 #FxUnitLabel[highlight="1"],

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -1222,6 +1222,10 @@ WEffectSelector,
   #Deck4 WStarRating, #DeckCompact4 WStarRating {
     color: #559b99;
   }
+/* Prevent cut-off or shifted stars on macOS */
+WStarRating {
+  background-color: #19191a;
+}
 
 /* Grey for FxUnit labels */
 #FxUnitLabel,


### PR DESCRIPTION
paleMoon decks look like this:
![image](https://user-images.githubusercontent.com/5934199/91665189-1bf23780-eaf4-11ea-917e-7c544f9eee8c.png)
