### PR TITLE
allow to hide the menu bar with [Controls],show_menubar

### DIFF
--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -1629,6 +1629,18 @@ WPushButton[value="2"]:hover,
     border: 1px solid #0080BE;
 }
 
+#MenubarToggle {
+  font-size: 14px;
+  font-weight: bold;
+  color: #888;
+  margin-top: 2px;
+  background-color: transparent;
+  border: none;
+  }
+  #MenubarToggle[hover="true"] {
+    color: #aaa;
+  }
+
 #HotcueButton {
   border: none;
 }

--- a/res/skins/Deere/tool_bar.xml
+++ b/res/skins/Deere/tool_bar.xml
@@ -11,6 +11,19 @@
     <SizePolicy>min,f</SizePolicy>
     <Children>
 
+      <!-- If [Controls],show_menubar is not available on macOS,
+        hide this with "max-width: 0px;" in style-mac.qss -->
+      <Template src="skin:left_2state_button.xml">
+        <SetVariable name="TooltipId">FIXME</SetVariable>
+        <SetVariable name="ObjectName">MenubarToggle</SetVariable>
+        <SetVariable name="MinimumSize">70,22</SetVariable>
+        <SetVariable name="MaximumSize">70,22</SetVariable>
+        <SetVariable name="SizePolicy">f,f</SetVariable>
+        <SetVariable name="state_0_text">&#x2630; MENU</SetVariable>
+        <SetVariable name="state_1_text">&#x2630; MENU</SetVariable>
+        <SetVariable name="left_connection_control">[Controls],show_menubar</SetVariable>
+      </Template>
+
       <Battery>
         <ObjectName>Battery</ObjectName>
         <Size>24,24</Size>

--- a/res/skins/Deere/tool_bar.xml
+++ b/res/skins/Deere/tool_bar.xml
@@ -13,7 +13,7 @@
 
       <!-- If [Controls],show_menubar is not available on macOS,
         hide this with "max-width: 0px;" in style-mac.qss -->
-      <Template src="skin:left_2state_button.xml">
+      <!-- <Template src="skin:left_2state_button.xml">
         <SetVariable name="TooltipId">FIXME</SetVariable>
         <SetVariable name="ObjectName">MenubarToggle</SetVariable>
         <SetVariable name="MinimumSize">70,22</SetVariable>
@@ -22,7 +22,7 @@
         <SetVariable name="state_0_text">&#x2630; MENU</SetVariable>
         <SetVariable name="state_1_text">&#x2630; MENU</SetVariable>
         <SetVariable name="left_connection_control">[Controls],show_menubar</SetVariable>
-      </Template>
+      </Template> -->
 
       <Battery>
         <ObjectName>Battery</ObjectName>

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -236,7 +236,8 @@ WEffectChainPresetSelector QAbstractScrollArea,
 #PreviewTitle,
 #PreviewLabel,
 WBeatSpinBox,
-#spinBoxTransition {
+#spinBoxTransition,
+#MenubarToggle {
   font-size: 14px;
 }
 

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -1321,13 +1321,16 @@ WEffectChainPresetSelector:!editable:on,
 WEffectSelector QAbstractScrollArea,
 WEffectChainPresetSelector QAbstractScrollArea,
 #fadeModeCombobox QAbstractScrollArea,
-#GuiToggleButton[displayValue="0"],
+#GuiToggleButton[displayValue="0"], #MenubarToggle,
 #RecDuration[highlight="0"],
 #BroadcastButton[displayValue="0"],
 #SkinSettingsToggle[displayValue="0"],
 #LibraryFeatureControls QLabel {
   color: #777;
-}
+  }/*
+  #MenubarToggle[hover="true"] {
+    color: #999;
+  }*/
 
 /* Darker grey for knob labels & inactive decks/units */
 #KnobLabel,

--- a/res/skins/LateNight/toolbar.xml
+++ b/res/skins/LateNight/toolbar.xml
@@ -5,6 +5,22 @@
     <SizePolicy>e,min</SizePolicy>
     <Children>
 
+      <!-- If [Controls],show_menubar is not available on macOS,
+        hide those two items with stylesheet with "max-width: 0px;" -->
+      <Template src="skin:/controls/button_2state.xml">
+        <SetVariable name="TooltipId">FIXME</SetVariable>
+        <SetVariable name="ObjectName">MenubarToggle</SetVariable>
+        <SetVariable name="Size">70f,20f</SetVariable>
+        <SetVariable name="state_0_text">&#x2630; MENU</SetVariable>
+        <SetVariable name="state_1_text">&#x2630; MENU</SetVariable>
+        <SetVariable name="ConfigKey">[Controls],show_menubar</SetVariable>
+      </Template>
+
+      <WidgetGroup>
+        <ObjectName>MenubarToggleSeparator</ObjectName>
+        <Size>12f,9min</Size>
+      </WidgetGroup>
+
       <Template src="skin:/controls/button_2state.xml">
         <SetVariable name="TooltipId">maximize_library</SetVariable>
         <SetVariable name="ObjectName">GuiToggleButton</SetVariable>

--- a/res/skins/LateNight/toolbar.xml
+++ b/res/skins/LateNight/toolbar.xml
@@ -7,14 +7,14 @@
 
       <!-- If [Controls],show_menubar is not available on macOS,
         hide those two items with stylesheet with "max-width: 0px;" -->
-      <Template src="skin:/controls/button_2state.xml">
+      <!-- <Template src="skin:/controls/button_2state.xml">
         <SetVariable name="TooltipId">FIXME</SetVariable>
         <SetVariable name="ObjectName">MenubarToggle</SetVariable>
         <SetVariable name="Size">70f,20f</SetVariable>
         <SetVariable name="state_0_text">&#x2630; MENU</SetVariable>
         <SetVariable name="state_1_text">&#x2630; MENU</SetVariable>
         <SetVariable name="ConfigKey">[Controls],show_menubar</SetVariable>
-      </Template>
+      </Template> -->
 
       <WidgetGroup>
         <ObjectName>MenubarToggleSeparator</ObjectName>

--- a/res/skins/Shade/skin.xml
+++ b/res/skins/Shade/skin.xml
@@ -61,6 +61,7 @@
       <attribute config_key="[Master],num_decks">2</attribute>
       <attribute config_key="[Master],num_samplers">8</attribute>
       <attribute config_key="[Master],num_preview_decks">1</attribute>
+      <attribute config_key="[Controls],show_menubar">1</attribute>
       <!--Optionally, make elements visible on skin load-->
       <attribute persist="true" config_key="[Spinny1],show_spinny">1</attribute>
       <attribute persist="true" config_key="[Spinny2],show_spinny">1</attribute>

--- a/res/skins/Shade/skin.xml
+++ b/res/skins/Shade/skin.xml
@@ -61,7 +61,6 @@
       <attribute config_key="[Master],num_decks">2</attribute>
       <attribute config_key="[Master],num_samplers">8</attribute>
       <attribute config_key="[Master],num_preview_decks">1</attribute>
-      <attribute config_key="[Controls],show_menubar">1</attribute>
       <!--Optionally, make elements visible on skin load-->
       <attribute persist="true" config_key="[Spinny1],show_spinny">1</attribute>
       <attribute persist="true" config_key="[Spinny2],show_spinny">1</attribute>

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -321,6 +321,16 @@ WWidgetGroup {
   qproperty-layoutAlignment: 'AlignLeft | AlignVCenter';
 }
 
+#MenubarToggle {
+  font-size: 14px;
+  font-weight: bold;
+  color: #888;
+  margin-top: 2px;
+  }
+  #MenubarToggle[hover="true"] {
+    color: #aaa;
+  }
+
 #GuiToggleButton,
 #GuiToggleButton2,
 #RecordingButton {

--- a/res/skins/Tango/topbar.xml
+++ b/res/skins/Tango/topbar.xml
@@ -32,6 +32,18 @@ Description:
 
               <WidgetGroup><Size>2f,0min</Size></WidgetGroup>
 
+
+              <!-- If [Controls],show_menubar is not available on macOS,
+                hide this with "max-width: 0px;" in style-mac.qss -->
+              <Template src="skin:button_2state.xml">
+                <SetVariable name="TooltipId">FIXME</SetVariable>
+                <SetVariable name="ObjectName">MenubarToggle</SetVariable>
+                <SetVariable name="Size">70f,22f</SetVariable>
+                <SetVariable name="state_0_text">&#x2630; MENU</SetVariable>
+                <SetVariable name="state_1_text">&#x2630; MENU</SetVariable>
+                <SetVariable name="ConfigKey">[Controls],show_menubar</SetVariable>
+              </Template>
+
               <PushButton>
                 <Size>102f,24f</Size>
                 <NumberStates>2</NumberStates>

--- a/res/skins/Tango/topbar.xml
+++ b/res/skins/Tango/topbar.xml
@@ -35,14 +35,14 @@ Description:
 
               <!-- If [Controls],show_menubar is not available on macOS,
                 hide this with "max-width: 0px;" in style-mac.qss -->
-              <Template src="skin:button_2state.xml">
+              <!-- <Template src="skin:button_2state.xml">
                 <SetVariable name="TooltipId">FIXME</SetVariable>
                 <SetVariable name="ObjectName">MenubarToggle</SetVariable>
                 <SetVariable name="Size">70f,22f</SetVariable>
                 <SetVariable name="state_0_text">&#x2630; MENU</SetVariable>
                 <SetVariable name="state_1_text">&#x2630; MENU</SetVariable>
                 <SetVariable name="ConfigKey">[Controls],show_menubar</SetVariable>
-              </Template>
+              </Template> -->
 
               <PushButton>
                 <Size>102f,24f</Size>

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -296,6 +296,8 @@ void MixxxMainWindow::initialize() {
     // Show the menubar after the launch image is replaced by the skin widget,
     // otherwise it would shift the launch image shortly before the skin is visible.
     m_pMenuBar->show();
+    // ToDo Parse command line args for --hide-menu-bar
+    m_pMenuBar->updateShowHideMenuBarFromCfg();
 
     // The launch image widget is automatically disposed, but we still have a
     // pointer to it.

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -296,13 +296,29 @@ void MixxxMainWindow::initialize() {
     // Show the menubar after the launch image is replaced by the skin widget,
     // otherwise it would shift the launch image shortly before the skin is visible.
     m_pMenuBar->show();
-    // ToDo Parse command line args for --hide-menu-bar
-    m_pMenuBar->updateShowHideMenuBarFromCfg();
+
+    // Hide the menu bar
+    // Note: all keyboard shortcuts still work (Ctrl+P for the preferences) and
+    // all menus can still be unrolled (Alt+F for the File menu, Alt+H for Help etc,)
+    // This is not the case if we simply remove m_pMenuBar->show above
+    // Var 1: via command line arg --hide-menu-bar
+    if (CmdlineArgs::Instance().getHideMenuBar()) {
+        m_pMenuBar->showHideMenuBar(0.0);
+    }
+    // Var 2: via mixxx.cfg:
+    // [Controls]
+    // show_menubar 0
+    //m_pMenuBar->updateShowHideMenuBarFromCfg();
 
     // The launch image widget is automatically disposed, but we still have a
     // pointer to it.
     m_pLaunchImage = nullptr;
 
+    // Note: if the menu bar should be hidden to achieve some kind of 'locked' mode
+    // i.e. keep users changing any settings, the below connections need to be
+    // disabled as well (popups that allow to configure previously unconfigured
+    // sound devices, for eaxmple when clicking the Passthrough button.
+    // >>>>
     connect(pPlayerManager.get(),
             &PlayerManager::noMicrophoneInputConfigured,
             this,
@@ -319,6 +335,7 @@ void MixxxMainWindow::initialize() {
             &PlayerManager::noVinylControlInputConfigured,
             this,
             &MixxxMainWindow::slotNoVinylControlInputConfigured);
+    // <<<<
 
     connect(&PlayerInfo::instance(),
             &PlayerInfo::currentPlayingTrackChanged,

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -121,6 +121,13 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     parser.addOption(fullScreen);
     parser.addOption(fullScreenDeprecated);
 
+    const QCommandLineOption hideMenuBar(
+            QStringList({QStringLiteral("hide-menu-bar")}),
+            forUserFeedback ? QCoreApplication::translate(
+                                      "CmdlineArgs", "Hide the main menu bar when Mixxx starts")
+                            : QString());
+    parser.addOption(hideMenuBar);
+
     const QCommandLineOption locale(QStringLiteral("locale"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "Use a custom locale for loading translations. (e.g "
@@ -294,6 +301,8 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     }
 
     m_startInFullscreen = parser.isSet(fullScreen) || parser.isSet(fullScreenDeprecated);
+
+    m_hideMenuBar = parser.isSet(hideMenuBar);
 
     if (parser.isSet(locale)) {
         m_locale = parser.value(locale);

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -31,6 +31,7 @@ class CmdlineArgs final {
 
     const QList<QString>& getMusicFiles() const { return m_musicFiles; }
     bool getStartInFullscreen() const { return m_startInFullscreen; }
+    bool getHideMenuBar() const { return m_hideMenuBar; }
     bool getControllerDebug() const {
         return m_controllerDebug;
     }
@@ -72,6 +73,7 @@ class CmdlineArgs final {
 
     QList<QString> m_musicFiles;    // List of files to load into players at startup
     bool m_startInFullscreen;       // Start in fullscreen mode
+    bool m_hideMenuBar;             // Hide the menu bar
     bool m_controllerDebug;
     bool m_developer; // Developer Mode
     bool m_qml;

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -79,6 +79,15 @@ WMainMenuBar::WMainMenuBar(QWidget* pParent, UserSettingsPointer pConfig,
 }
 
 void WMainMenuBar::initialize() {
+    // Allow hiding the menu bar
+    m_bShowMenuBar = std::make_unique<ControlPushButton>(
+            ConfigKey("[Controls]", "show_menubar"), false, 1.0);
+    m_bShowMenuBar->setButtonMode(ControlPushButton::TOGGLE);
+    connect(m_bShowMenuBar.get(),
+            &ControlPushButton::valueChanged,
+            this,
+            &WMainMenuBar::showHideMenuBar);
+
     // FILE MENU
     QMenu* pFileMenu = new QMenu(tr("&File"), this);
 
@@ -637,6 +646,17 @@ void WMainMenuBar::initialize() {
 
     pHelpMenu->addAction(pHelpAboutApp);
     addMenu(pHelpMenu);
+}
+
+void WMainMenuBar::showHideMenuBar(double v) {
+    if (v > 0) {
+        int minHeight = sizeHint().height();
+        if (minHeight > 0) {
+            setFixedHeight(minHeight);
+        }
+    } else {
+        setFixedHeight(0);
+    }
 }
 
 void WMainMenuBar::onKeywheelChange(int state) {

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -659,9 +659,9 @@ void WMainMenuBar::showHideMenuBar(double v) {
         setFixedHeight(0);
     }
     m_bShowMenuBar->forceSet(v);
-    // Store new value in config if visibility is changed with
-    // (re-enabled) skin toggles or in developer tools
-    m_pConfig->setValue(kConfigkeyShowMenuBar, v);
+    // Uncomment this if yo want to store new value in config aftre visibility
+    // was changed with (re-enabled) skin toggles or in developer tools
+    //m_pConfig->setValue(kConfigkeyShowMenuBar, v);
 }
 
 void WMainMenuBar::updateShowHideMenuBarFromCfg() {

--- a/src/widget/wmainmenubar.h
+++ b/src/widget/wmainmenubar.h
@@ -41,6 +41,7 @@ class WMainMenuBar : public QMenuBar {
 
   public slots:
     void showHideMenuBar(double v);
+    void updateShowHideMenuBarFromCfg();
     void onLibraryScanStarted();
     void onLibraryScanFinished();
     void onRecordingStateChange(bool recording);

--- a/src/widget/wmainmenubar.h
+++ b/src/widget/wmainmenubar.h
@@ -6,9 +6,12 @@
 #include <QObject>
 #include <QScopedPointer>
 
+#include "control/controlobject.h"
 #include "control/controlproxy.h"
+#include "control/controlpushbutton.h"
 #include "preferences/configobject.h"
 #include "preferences/usersettings.h"
+#include "util/memory.h"
 
 class VisibilityControlConnection : public QObject {
     Q_OBJECT
@@ -37,6 +40,7 @@ class WMainMenuBar : public QMenuBar {
                  ConfigObject<ConfigValueKbd>* pKbdConfig);
 
   public slots:
+    void showHideMenuBar(double v);
     void onLibraryScanStarted();
     void onLibraryScanFinished();
     void onRecordingStateChange(bool recording);
@@ -90,6 +94,7 @@ class WMainMenuBar : public QMenuBar {
     void initialize();
     void createVisibilityControl(QAction* pAction, const ConfigKey& key);
 
+    std::unique_ptr<ControlPushButton> m_bShowMenuBar;
     UserSettingsPointer m_pConfig;
     QAction* m_pViewKeywheel;
     ConfigObject<ConfigValueKbd>* m_pKbdConfig;


### PR DESCRIPTION
* ce13b75afb430d91a270a3624a584f21ca7bbdf2 adds the toggle to c++ which allows to hide the menu bar in different ways:
  * add `<attribute config_key="[Controls],show_menubar">0</attribute>` to the skin manifest
  * toggle `[Controls],show_menubar` with controllers (direct binding and scripts, e.g. `init() function`) or keyboards
  * add UI toggles (following commit)
* 8a529752a18c6c424ef7e9c818e073a6a7ff57bb adds the buttons to official skins, default: menu bar visible
* b6bc9fb looks for `[Controls]` `show_menubar` in `mixxx.cfg`, skin toggles are hidden
* 1a7954a looks for command line argument `--hide-menu-bar`, parsing the config is disabled (see inline comments, also for 'locked' mode)