### PR TITLE
Search bpm fuzzy halfdouble

### DIFF
--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -645,10 +645,20 @@ BpmFilterNode::BpmFilterNode(QString& argument, bool fuzzy, bool negate)
         // We find everything that is displayed as 127.** in the library
         m_rangeLower = bpm - kLibraryRoundRange; // [126.95
         m_rangeUpper = bpm + 1;                  // ]128
-        // In case bpm / 2 is a fractional, we include the *.0 value neighbours
-        // since fractional bpm values are less common in some genres.
-        m_bpmHalfLower = floor(bpm / 2); // [63
-        m_bpmHalfUpper = ceil(bpm / 2);  // 64]
+
+        double halfBpm = bpm / 2;
+        qDebug() << "if (floor(halfBpm) != halfBpm) {" << floor(halfBpm) << halfBpm;
+        if (floor(halfBpm) != halfBpm) {
+            // In case bpm / 2 is a fractional, we include the *.0 value neighbours
+            // since fractional bpm values are less common in some genres.
+            m_bpmHalfLower = floor(halfBpm) - kLibraryRoundRange; // [62.95
+            m_bpmHalfUpper = halfBpm + 1;                         // ]64.5
+        } else {
+            // Here we are for instance with 126
+            // We find everything that is displayed as 63.** in the library
+            m_bpmHalfLower = halfBpm - kLibraryRoundRange; // [62.95
+            m_bpmHalfUpper = halfBpm + 1;                  // ]64
+        }
         // We find everything which would be found when editing the beat grid via / 2
         m_bpmDoubleLower = (bpm * 2) - kLibraryRoundRange; // [253.95
         m_bpmDoubleUpper = m_rangeUpper * 2;               // ]256
@@ -729,7 +739,7 @@ QString BpmFilterNode::toSql() const {
     case MatchMode::HalveDouble: {
         QStringList searchClauses;
         searchClauses << rangeUpperExclusiveSqlString(m_rangeLower, m_rangeUpper);
-        searchClauses << rangeSqlString(m_bpmHalfLower, m_bpmHalfUpper);
+        searchClauses << rangeUpperExclusiveSqlString(m_bpmHalfLower, m_bpmHalfUpper);
         searchClauses << rangeUpperExclusiveSqlString(m_bpmDoubleLower, m_bpmDoubleUpper);
         return concatSqlClauses(searchClauses, "OR");
     }

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -498,16 +498,29 @@ TEST_F(SearchQueryParserTest, BpmFilter) {
     m_parser.setSearchColumns({"artist", "album"});
 
     // Test BpmFilter's MatchModes:
-    // HalveDouble
-    auto pQuery(m_parser.parseQuery("bpm:127", QString()));
+
+    // HalveDouble even
+    auto pQuery = m_parser.parseQuery("bpm:126", QString());
     TrackPointer pTrack = newTestTrack();
+    EXPECT_FALSE(pQuery->match(pTrack));
+    pTrack->trySetBpm(126.13);
+    EXPECT_TRUE(pQuery->match(pTrack));
+
+    EXPECT_STREQ(
+            qPrintable(QString("(bpm >= 125.95 AND bpm < 127) OR "
+                               "(bpm >= 62.95 AND bpm < 64) OR "
+                               "(bpm >= 251.95 AND bpm < 254)")),
+            qPrintable(pQuery->toSql()));
+
+    // HalveDouble uneven
+    pQuery = m_parser.parseQuery("bpm:127", QString());
     EXPECT_FALSE(pQuery->match(pTrack));
     pTrack->trySetBpm(127.13);
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
             qPrintable(QString("(bpm >= 126.95 AND bpm < 128) OR "
-                               "(bpm BETWEEN 63 AND 64) OR "
+                               "(bpm >= 62.95 AND bpm < 64.5) OR "
                                "(bpm >= 253.95 AND bpm < 256)")),
             qPrintable(pQuery->toSql()));
 


### PR DESCRIPTION
I have notices that a even value only matches the exact .0 value. 
This PR fixes this and also extend the uneven range a bit.  

bpm | Bpm/2 | low | high (exlusive) | in Library 
-- | -- | -- | -- | --
126 | 63 | 62,95 | 64 | 63.0 .. 63.9
127 | 63,5 | 62,95 | 64,5 | 63.0 .. 64.4
128 | 64 | 63,95 | 65 | 64.0 .. 64.9
129 | 64,5 | 63,95 | 65,5 | 64.0 .. 63.4
130 | 65 | 64,95 | 66 | 65.0 .. 65.9


