### PR TITLE
Add track move commands to controls library

### DIFF
--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -166,6 +166,29 @@ LibraryControl::LibraryControl(Library* pLibrary)
                 &LibraryControl::slotMoveFocus);
     }
 
+    // Controls to move tracks on playlist
+    // Track move controls (emulate Alt+up/down button press)
+    m_pMoveTrackForward = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "MoveTrackForward"));
+    m_pMoveTrackBackward = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "MoveTrackBackward"));
+    m_pMoveTrack = std::make_unique<ControlEncoder>(ConfigKey("[Library]", "MoveTrack"), false);
+#ifdef MIXXX_USE_QML
+    if (!CmdlineArgs::Instance().isQml())
+#endif
+    {
+        connect(m_pMoveTrackForward.get(),
+                &ControlPushButton::valueChanged,
+                this,
+                &LibraryControl::slotMoveTrackForward);
+        connect(m_pMoveTrackBackward.get(),
+                &ControlPushButton::valueChanged,
+                this,
+                &LibraryControl::slotMoveTrackBackward);
+        connect(m_pMoveTrack.get(),
+                &ControlEncoder::valueChanged,
+                this,
+                &LibraryControl::slotMoveTrack);
+    }
+
     // Direct focus control, read/write
     m_pFocusedWidgetCO = std::make_unique<ControlPushButton>(
             ConfigKey("[Library]", "focused_widget"));
@@ -791,6 +814,25 @@ void LibraryControl::slotMoveFocus(double v) {
     const auto times = static_cast<unsigned short>(std::abs(v));
     emitKeyEvent(QKeyEvent{
             QEvent::KeyPress, key, Qt::NoModifier, QString(), false, times});
+}
+
+void LibraryControl::slotMoveTrackForward(double v) {
+    if (v > 0) {
+        slotMoveTrack(1);
+    }
+}
+
+void LibraryControl::slotMoveTrackBackward(double v) {
+    if (v > 0) {
+        slotMoveTrack(-1);
+    }
+}
+
+void LibraryControl::slotMoveTrack(double v) {
+    const auto key = (v < 0) ? Qt::Key_Up : Qt::Key_Down;
+    const auto times = static_cast<unsigned short>(std::abs(v));
+    emitKeyEvent(QKeyEvent{
+            QEvent::KeyPress, key, Qt::AltModifier, QString(), false, times});
 }
 
 void LibraryControl::emitKeyEvent(QKeyEvent&& event) {

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -79,6 +79,9 @@ class LibraryControl : public QObject {
     void slotMoveFocusForward(double);
     void slotMoveFocusBackward(double);
     void slotMoveFocus(double);
+    void slotMoveTrackForward(double);
+    void slotMoveTrackBackward(double);
+    void slotMoveTrack(double);
     void slotGoToItem(double v);
 
     void slotTrackColorPrev(double v);
@@ -139,6 +142,11 @@ class LibraryControl : public QObject {
     FocusWidget m_focusedWidget;
     std::unique_ptr<ControlPushButton> m_pRefocusPrevWidgetCO;
     FocusWidget m_prevFocusedWidget;
+
+    // Controls to move tracks (alt+up/down buttons)
+    std::unique_ptr<ControlPushButton> m_pMoveTrackForward;
+    std::unique_ptr<ControlPushButton> m_pMoveTrackBackward;
+    std::unique_ptr<ControlEncoder> m_pMoveTrack;
 
     // Control to choose the currently selected item in focused widget (double click)
     std::unique_ptr<ControlObject> m_pGoToItem;


### PR DESCRIPTION
Add track move to controls library by emulating alt+up/down.