### PR TITLE
Search or in parenthesis

### DIFF
--- a/src/library/searchqueryparser.cpp
+++ b/src/library/searchqueryparser.cpp
@@ -53,6 +53,18 @@ std::pair<QString, Quoted> consumeQuotedArgument(QString argument,
     return {argument, Quoted::Complete};
 }
 
+bool hasClosingParenthesis(const QString& token, const QStringList& tokens) {
+    if (token.contains(")")) {
+        return true;
+    }
+    for (const QString& t : tokens) {
+        if (t.contains(")")) {
+            return true;
+        }
+    }
+    return false;
+}
+
 } // anonymous namespace
 
 constexpr char kNegatePrefix[] = "-";
@@ -64,8 +76,9 @@ constexpr char kFuzzyPrefix[] = "~";
 const QRegularExpression kSplitIntoWordsRegexp = QRegularExpression(
         QStringLiteral(" " QUOTED_STRING_LOOKAHEAD));
 
+// Matches ' OR ' (case-sensitive) or the '|' character
 const QRegularExpression kSplitOnOrOperatorRegexp = QRegularExpression(
-        QStringLiteral("(?:\\||\\bOR\\b)" QUOTED_STRING_LOOKAHEAD));
+        QStringLiteral("(?:\\||\\bOR\\b)"));
 
 SearchQueryParser::SearchQueryParser(TrackCollection* pTrackCollection, QStringList searchColumns)
         : m_pTrackCollection(pTrackCollection),
@@ -192,6 +205,22 @@ SearchQueryParser::TextArgumentResult SearchQueryParser::getTextArgument(QString
 
 void SearchQueryParser::parseTokens(QStringList tokens,
                                     AndNode* pQuery) const {
+    // This lambda avoids duplication in the branches for
+    // 1) nested OR (invalid query or literal '(||)') and
+    // 2) plain text/crate queries.
+    auto createUntaggedNode = [&](const QString& arg) {
+        if (m_searchCrates) {
+            auto gNode = std::make_unique<OrNode>();
+            gNode->addNode(std::make_unique<CrateFilterNode>(
+                    &m_pTrackCollection->crates(), arg));
+            gNode->addNode(std::make_unique<TextFilterNode>(
+                    m_pTrackCollection->database(), m_queryColumns, arg));
+            return std::unique_ptr<QueryNode>(std::move(gNode));
+        }
+        return std::unique_ptr<QueryNode>(std::make_unique<TextFilterNode>(
+                m_pTrackCollection->database(), m_queryColumns, arg));
+    };
+
     while (tokens.size() > 0) {
         QString token = tokens.takeFirst().trimmed();
         if (token.length() == 0) {
@@ -290,6 +319,37 @@ void SearchQueryParser::parseTokens(QStringList tokens,
                             m_pTrackCollection->database());
                 }
             }
+        } else if (token.startsWith("(") && hasClosingParenthesis(token, tokens)) {
+            QString nestedQuery = token.mid(1);
+
+            // We found an opening ( and a closing ) somewhere.
+            // Now we collect tokens until we find the one containing the closing ')'
+            while (!nestedQuery.contains(")") && !tokens.isEmpty()) {
+                nestedQuery += " " + tokens.takeFirst();
+            }
+
+            // If there is text AFTER the ')', put it back in the tokens list
+            int closingIdx = nestedQuery.lastIndexOf(")");
+            DEBUG_ASSERT(closingIdx != -1);
+            qWarning() << "   > isolate parenthesis content";
+            if (closingIdx < nestedQuery.length()) {
+                const QString trailing = nestedQuery.mid(closingIdx + 1).trimmed();
+                if (!trailing.isEmpty()) {
+                    tokens.prepend(trailing);
+                }
+            }
+            nestedQuery = nestedQuery.left(closingIdx);
+
+            const QString trimmedNested = nestedQuery.trimmed();
+            if (trimmedNested.isEmpty() ||
+                    trimmedNested == QStringLiteral("OR") ||
+                    trimmedNested == QStringLiteral("|")) {
+                // Safeguard: If the parenthesis is empty or just an operator,
+                // we call our lambda to treat the whole thing as a literal term.
+                pNode = createUntaggedNode("(" + nestedQuery + ")");
+            } else {
+                pNode = parseOrNode(nestedQuery);
+            }
         } else {
             // If no advanced search feature matched, treat it as a search term.
             if (negate) {
@@ -297,21 +357,8 @@ void SearchQueryParser::parseTokens(QStringList tokens,
             }
             // Don't trigger on a lone minus sign.
             if (!token.isEmpty()) {
-                QString argument = getTextArgument(token, &tokens).argument;
-                // For untagged strings we search the track fields as well
-                // as the crate names the track is in. This allows the user
-                // to use crates like tags
-                if (m_searchCrates) {
-                    auto gNode = std::make_unique<OrNode>();
-                    gNode->addNode(std::make_unique<CrateFilterNode>(
-                                    &m_pTrackCollection->crates(), argument));
-                    gNode->addNode(std::make_unique<TextFilterNode>(
-                            m_pTrackCollection->database(), m_queryColumns, argument));
-                    pNode = std::move(gNode);
-                } else {
-                    pNode = std::make_unique<TextFilterNode>(
-                            m_pTrackCollection->database(), m_queryColumns, argument);
-                }
+                const QString argument = getTextArgument(token, &tokens).argument;
+                pNode = createUntaggedNode(argument);
             }
         }
         if (pNode) {
@@ -335,12 +382,8 @@ std::unique_ptr<AndNode> SearchQueryParser::parseAndNode(const QString& query) c
 std::unique_ptr<OrNode> SearchQueryParser::parseOrNode(const QString& query) const {
     auto pQuery = std::make_unique<OrNode>();
 
-    const QStringList rawAndNodes = query.split(kSplitOnOrOperatorRegexp,
-#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
-            Qt::SkipEmptyParts);
-#else
-            QString::SkipEmptyParts);
-#endif
+    const QStringList rawAndNodes = splitTopLevelOr(query);
+
     for (const QString& rawAndNode : rawAndNodes) {
         if (!rawAndNode.isEmpty()) {
             pQuery->addNode(parseAndNode(rawAndNode));
@@ -374,6 +417,58 @@ QStringList SearchQueryParser::splitQueryIntoWords(const QString& query) {
             QString::SkipEmptyParts);
 #endif
     return queryWordList;
+}
+
+QStringList SearchQueryParser::splitTopLevelOr(const QString& query) const {
+    QStringList parts;
+    int lastSplitPos = 0;  // start of the current segment
+    int scanPos = 0;       // count of chars we've checked for quotes/parenthesis
+    int parenthLevel = 0;  //
+    bool inQuotes = false; // is the current OR/| in quotes or not
+
+    QRegularExpressionMatchIterator it = kSplitOnOrOperatorRegexp.globalMatch(query);
+
+    while (it.hasNext()) {
+        // Nth occurrence of OR/|
+        QRegularExpressionMatch match = it.next();
+        // position of 'O'/'|'
+        int matchPos = match.capturedStart();
+
+        // scan characters since the last match (pos after last 'R'/'|')
+        // for quotes.
+        for (; scanPos < matchPos; ++scanPos) {
+            const QChar c = query[scanPos];
+            if (c == '\"') {
+                // toggle quote state
+                inQuotes = !inQuotes;
+            } else if (!inQuotes) {
+                // sount parenthesis if we aren't inside a quoted string
+                if (c == '(') {
+                    parenthLevel++;
+                } else if (c == ')') {
+                    parenthLevel--;
+                }
+            }
+        }
+
+        // split if we are at the top level AND not in quotes
+        if (!inQuotes && parenthLevel == 0) {
+            parts << query.mid(lastSplitPos, matchPos - lastSplitPos).trimmed();
+            lastSplitPos = match.capturedEnd();
+        }
+
+        // advance the scan position past the operator so we have a start
+        // position for the next scan
+        scanPos = match.capturedEnd();
+    }
+
+    // capture the final segment
+    const QString finalPart = query.mid(lastSplitPos).trimmed();
+    if (!finalPart.isEmpty()) {
+        parts << finalPart;
+    }
+
+    return parts;
 }
 
 bool SearchQueryParser::queryIsLessSpecific(const QString& original, const QString& changed) {

--- a/src/library/searchqueryparser.cpp
+++ b/src/library/searchqueryparser.cpp
@@ -205,6 +205,7 @@ SearchQueryParser::TextArgumentResult SearchQueryParser::getTextArgument(QString
 
 void SearchQueryParser::parseTokens(QStringList tokens,
                                     AndNode* pQuery) const {
+    qWarning() << "-> parseTokens";
     // This lambda avoids duplication in the branches for
     // 1) nested OR (invalid query or literal '(||)') and
     // 2) plain text/crate queries.
@@ -234,6 +235,7 @@ void SearchQueryParser::parseTokens(QStringList tokens,
         const QRegularExpressionMatch numericFilterMatch = m_numericFilterMatcher.match(token);
         const QRegularExpressionMatch specialFilterMatch = m_specialFilterMatcher.match(token);
         if (textFilterMatch.hasMatch()) {
+            qWarning() << "  >text filter" << token;
             QString field = textFilterMatch.captured(1);
             auto [argument, matchMode] = getTextArgument(textFilterMatch.captured(2), &tokens);
 
@@ -261,6 +263,7 @@ void SearchQueryParser::parseTokens(QStringList tokens,
                 }
             }
         } else if (numericFilterMatch.hasMatch()) {
+            qWarning() << "  >num filter" << token;
             QString field = numericFilterMatch.captured(1);
             QString argument = getTextArgument(numericFilterMatch.captured(2), &tokens).argument;
 
@@ -274,6 +277,7 @@ void SearchQueryParser::parseTokens(QStringList tokens,
                 }
             }
         } else if (specialFilterMatch.hasMatch()) {
+            qWarning() << "  >special filter:" << token;
             bool fuzzy = token.startsWith(kFuzzyPrefix);
             bool negate = token.startsWith(kNegatePrefix);
             QString field = specialFilterMatch.captured(1);
@@ -320,6 +324,7 @@ void SearchQueryParser::parseTokens(QStringList tokens,
                 }
             }
         } else if (token.startsWith("(") && hasClosingParenthesis(token, tokens)) {
+            qWarning() << "  >(...) query" << token;
             QString nestedQuery = token.mid(1);
 
             // We found an opening ( and a closing ) somewhere.
@@ -330,10 +335,13 @@ void SearchQueryParser::parseTokens(QStringList tokens,
 
             // If there is text AFTER the ')', put it back in the tokens list
             int closingIdx = nestedQuery.lastIndexOf(")");
+            qWarning() << "   > closing idx:" << closingIdx;
             DEBUG_ASSERT(closingIdx != -1);
             qWarning() << "   > isolate parenthesis content";
             if (closingIdx < nestedQuery.length()) {
+                qWarning() << "   >> text after closingIdx";
                 const QString trailing = nestedQuery.mid(closingIdx + 1).trimmed();
+                qWarning() << "   >> trailing:" << trailing;
                 if (!trailing.isEmpty()) {
                     tokens.prepend(trailing);
                 }
@@ -346,11 +354,14 @@ void SearchQueryParser::parseTokens(QStringList tokens,
                     trimmedNested == QStringLiteral("|")) {
                 // Safeguard: If the parenthesis is empty or just an operator,
                 // we call our lambda to treat the whole thing as a literal term.
+                qWarning() << "   > ! nested query is empty or operator, "
+                              "falling back to literal";
                 pNode = createUntaggedNode("(" + nestedQuery + ")");
             } else {
                 pNode = parseOrNode(nestedQuery);
             }
         } else {
+            qWarning() << "  >else/untagged" << token;
             // If no advanced search feature matched, treat it as a search term.
             if (negate) {
                 token = token.mid(1);
@@ -380,6 +391,7 @@ std::unique_ptr<AndNode> SearchQueryParser::parseAndNode(const QString& query) c
 }
 
 std::unique_ptr<OrNode> SearchQueryParser::parseOrNode(const QString& query) const {
+    qWarning() << "---> parseOrNode (Manual Split):" << query;
     auto pQuery = std::make_unique<OrNode>();
 
     const QStringList rawAndNodes = splitTopLevelOr(query);
@@ -399,7 +411,10 @@ std::unique_ptr<QueryNode> SearchQueryParser::parseQuery(
     auto pQuery(std::make_unique<AndNode>());
 
     if (!extraFilter.isEmpty()) {
+        qWarning() << "> parseQuery" << query << "| extra:" << extraFilter;
         pQuery->addNode(std::make_unique<SqlNode>(extraFilter));
+    } else {
+        qWarning() << "> parseQuery" << query << "| extra:" << extraFilter;
     }
 
     if (!query.isEmpty()) {
@@ -420,6 +435,7 @@ QStringList SearchQueryParser::splitQueryIntoWords(const QString& query) {
 }
 
 QStringList SearchQueryParser::splitTopLevelOr(const QString& query) const {
+    qWarning() << "     splitTopLevelOr:" << query;
     QStringList parts;
     int lastSplitPos = 0;  // start of the current segment
     int scanPos = 0;       // count of chars we've checked for quotes/parenthesis
@@ -431,6 +447,7 @@ QStringList SearchQueryParser::splitTopLevelOr(const QString& query) const {
     while (it.hasNext()) {
         // Nth occurrence of OR/|
         QRegularExpressionMatch match = it.next();
+        qWarning() << "     -> it next:" << match.captured(0);
         // position of 'O'/'|'
         int matchPos = match.capturedStart();
 
@@ -453,6 +470,9 @@ QStringList SearchQueryParser::splitTopLevelOr(const QString& query) const {
 
         // split if we are at the top level AND not in quotes
         if (!inQuotes && parenthLevel == 0) {
+            qWarning() << "        found"
+                       << query.mid(lastSplitPos, matchPos - lastSplitPos)
+                                  .trimmed();
             parts << query.mid(lastSplitPos, matchPos - lastSplitPos).trimmed();
             lastSplitPos = match.capturedEnd();
         }
@@ -465,9 +485,14 @@ QStringList SearchQueryParser::splitTopLevelOr(const QString& query) const {
     // capture the final segment
     const QString finalPart = query.mid(lastSplitPos).trimmed();
     if (!finalPart.isEmpty()) {
+        qWarning() << "     -> finalPart:" << finalPart;
         parts << finalPart;
     }
 
+    qWarning() << "     -> parts: (" << parts.size() << ")";
+    for (const QString& part : std::as_const(parts)) {
+        qWarning() << "        " << part;
+    }
     return parts;
 }
 

--- a/src/library/searchqueryparser.h
+++ b/src/library/searchqueryparser.h
@@ -23,6 +23,10 @@ class SearchQueryParser {
 
     /// splits the query into a list of terms
     static QStringList splitQueryIntoWords(const QString& query);
+    /// splits the query (part) at ' OR ' or '|' at its top-level
+    /// ie. not inside parenthesis, not inside quotes.
+    /// called for the original query and, if available, isolated parts in parenthesis
+    QStringList splitTopLevelOr(const QString& query) const;
     /// checks if the changed search query is less specific then the original term
     static bool queryIsLessSpecific(const QString& original, const QString& changed);
 

--- a/src/library/searchqueryparser.h
+++ b/src/library/searchqueryparser.h
@@ -28,6 +28,7 @@ class SearchQueryParser {
     /// called for the original query and, if available, isolated parts in parenthesis
     QStringList splitTopLevelOr(const QString& query) const;
     /// checks if the changed search query is less specific then the original term
+    // TODO(ronso0) test if this still works with new multi-level OR split
     static bool queryIsLessSpecific(const QString& original, const QString& changed);
 
   private:


### PR DESCRIPTION
Before we had to do this
`shoe black|shoe purple|shoe white`
which makes BPM/genre OR queries quite long.

Now we can do
`shoe (black|purple|white)`

Still need to add tests and do manual testing for regressions